### PR TITLE
port over from recently updated cal and proc_cgi_frame

### DIFF
--- a/Calibration_NTR/cal/util/gsw_emccd_frame.py
+++ b/Calibration_NTR/cal/util/gsw_emccd_frame.py
@@ -151,7 +151,8 @@ class EMCCDFrame:
                             plat_thresh=plat_thresh,
                             cosm_filter=cosm_filter,
                             cosm_box=cosm_box,
-                            cosm_tail=cosm_tail
+                            cosm_tail=cosm_tail,
+                            meta=self.meta
                             )
         # same thing, but now making masks for full frame (for calibrate_darks)
 
@@ -167,6 +168,7 @@ class EMCCDFrame:
                             cosm_filter=cosm_filter,
                             cosm_box=cosm_box,
                             cosm_tail=cosm_tail,
+                            meta=self.meta,
                             mode='full'
                             )
 

--- a/Calibration_NTR/cal/util/gsw_remove_cosmics.py
+++ b/Calibration_NTR/cal/util/gsw_remove_cosmics.py
@@ -3,9 +3,10 @@
 
 import numpy as np
 from scipy.ndimage import median_filter
+from .read_metadata import Metadata
 
 def remove_cosmics(image, fwc, sat_thresh, plat_thresh, cosm_filter, cosm_box,
-                   cosm_tail, mode='image'):
+                   cosm_tail, meta=None, mode='image'):
     """Identify and remove saturated cosmic ray hits and tails.
 
     Use sat_thresh (interval 0 to 1) to set the threshold above which cosmics
@@ -44,6 +45,12 @@ def remove_cosmics(image, fwc, sat_thresh, plat_thresh, cosm_filter, cosm_box,
         to mask.  If cosm_tail is greater than the number of
         columns left to the end of the row from the cosmic
         plateau, the cosmic masking ends at the end of the row. Defaults to 10.
+    meta : Metadata class instance
+        Metadata class instance, which is used to determine whether the
+        beginning of a plateau is not in the image area, in which case no 
+        cosmic ray masking should occur.  Only relevant when mode is 'full'.
+        Defaults to None, in which case masking is allowed anywhere on the 
+        input frame.
     mode : string
         If 'image', an image-area input is assumed, and if the input
         tail length is longer than the length to the end of the image-area row,
@@ -70,9 +77,25 @@ def remove_cosmics(image, fwc, sat_thresh, plat_thresh, cosm_filter, cosm_box,
      ......|<-plateau->|<------------------tail---------->|.........
 
     B Nemati and S Miller - UAH - 02-Oct-2018
+    Kevin Ludwick - UAH - 2024
 
     """
     mask = np.zeros(image.shape, dtype=int)
+    if meta is not None:
+        if not isinstance(meta, Metadata):
+            raise Exception('meta must be an instance of the Metadata class.')
+    if meta is not None and mode=='full':
+        im_num_rows = meta.geom['image']['rows']
+        im_num_cols = meta.geom['image']['cols']
+        im_starting_row = meta.geom['image']['r0c0'][0]
+        im_ending_row = im_starting_row + im_num_rows
+        im_starting_col = meta.geom['image']['r0c0'][1]
+        im_ending_col = im_starting_col + im_num_cols
+    else:
+        im_starting_row = 0
+        im_ending_row = mask.shape[0] - 1 # - 1 to get the index, not size
+        im_starting_col = 0
+        im_ending_col = mask.shape[1] - 1 # - 1 to get the index, not size
 
     # Do a cheap prefilter for rows that don't have anything bright
     max_rows = np.max(image, axis=1)
@@ -80,7 +103,8 @@ def remove_cosmics(image, fwc, sat_thresh, plat_thresh, cosm_filter, cosm_box,
 
     for i in i_streak_rows:
         row = image[i]
-
+        if i < im_starting_row or i > im_ending_row:
+            continue
         # Find if and where saturated plateaus start in streak row
         i_begs = find_plateaus(row, fwc, sat_thresh, plat_thresh, cosm_filter)
 
@@ -89,6 +113,8 @@ def remove_cosmics(image, fwc, sat_thresh, plat_thresh, cosm_filter, cosm_box,
         ex_l = np.array([])
         if i_begs is not None:
             for i_beg in i_begs:
+                if i_beg < im_starting_col or i_beg > im_ending_col:
+                    continue
                 # implement cosm_tail
                 if i_beg+cosm_filter+cosm_tail+1 > mask.shape[1]:
                     ex_l = np.append(ex_l,
@@ -98,10 +124,11 @@ def remove_cosmics(image, fwc, sat_thresh, plat_thresh, cosm_filter, cosm_box,
                                 mask.shape[1]))
                 mask[i, i_beg:streak_end] = 1
                 # implement cosm_box
-                st_row = max(i-cosm_box, 0)
-                end_row = min(i+cosm_box+1, mask.shape[0])
-                st_col = max(i_beg-cosm_box, 0)
-                end_col = min(i_beg+cosm_box+1, mask.shape[1])
+                # can't have cosm_box appear in non-image pixels
+                st_row = max(i-cosm_box, im_starting_row)
+                end_row = min(i+cosm_box+1, im_ending_row+1)
+                st_col = max(i_beg-cosm_box, im_starting_col)
+                end_col = min(i_beg+cosm_box+1, im_ending_col+1)
                 mask[st_row:end_row, st_col:end_col] = 1
                 pass
 

--- a/Calibration_NTR/cal/util/ut_gsw_emccd_frame.py
+++ b/Calibration_NTR/cal/util/ut_gsw_emccd_frame.py
@@ -231,6 +231,9 @@ class TestRemoveCosmics(unittest.TestCase):
         self.cosm_filter = 2
         self.cosm_box = 0
         self.cosm_tail = 2200
+        self.meta = Metadata() # using metadata.yaml
+        self.im_st_row = self.meta.geom['image']['r0c0'][0]
+        self.im_st_col = self.meta.geom['image']['r0c0'][1]
         pass
 
     def test_cosm_box_works(self):
@@ -243,13 +246,17 @@ class TestRemoveCosmics(unittest.TestCase):
         """Verify method returns correct mask with a CR."""
         # full frame
         frame_bias0 = np.zeros((meta.frame_rows, meta.frame_cols))
-        frame_bias0[1:3, 2:4] = self.fwc_em  # Fake hit
-        frame_bias0[1:3, 4] = self.fwc_em/2  # Trigger end cosmic thresh
-        frame_bias0[1:3, 5:] = 1.  # Fake tail
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+2:self.im_st_col+4] = self.fwc_em  #Fake hit
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+4] = self.fwc_em/2#Trigger end cosmic thresh
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+5:] = 1.  # Fake tail
         self.frame.frame_bias0 = frame_bias0
         frame_mask = np.zeros_like(frame_bias0, dtype=int)
         # cosm_filter=2,cosm_tail=10, and mask starts at 2
-        frame_mask[1:3, 2:2+2+10+1] = 1
+        frame_mask[self.im_st_row+1:self.im_st_row+3, 
+                   self.im_st_col+2:self.im_st_col+2+2+10+1] = 1
 
         # image area
         image_bias0 = np.zeros((meta.geom['image']['rows'],
@@ -281,9 +288,13 @@ class TestRemoveCosmics(unittest.TestCase):
 
         # full frame
         frame_bias0 = np.zeros((meta.frame_rows, meta.frame_cols))
-        frame_bias0[1:3, 2:4] = self.fwc_pp - 1  # Fake hit *below threshold*
-        frame_bias0[1:3, 4] = self.fwc_pp/2  # Trigger end cosmic thresh
-        frame_bias0[1:3, 5:] = 1.  # Fake tail
+        # Fake hit *below threshold*
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+2:self.im_st_col+4] = self.fwc_pp - 1  
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+4] = self.fwc_pp/2#Trigger end cosmic thresh
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+5:] = 1.  # Fake tail
         self.frame.frame_bias0 = frame_bias0
 
         # image area
@@ -318,10 +329,14 @@ class TestRemoveCosmics(unittest.TestCase):
 
         # full frame
         frame_bias0 = np.zeros((meta.frame_rows, meta.frame_cols))
-        frame_bias0[1:3, 2:4] = self.fwc_em  # Fake hit
-        frame_bias0[1:3, 4] = self.fwc_em/2  # Trigger end cosmic thresh
-        frame_bias0[1:3, 5:] = 1.  # Fake tail
-        frame_bias0[8, 8] = self.fwc_em # isolated pixel
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+2:self.im_st_col+4] = self.fwc_em  #Fake hit
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+4] = self.fwc_em/2#Trigger end cosmic thresh
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+5:] = 1.  # Fake tail
+        frame_bias0[self.im_st_row+8, 
+                    self.im_st_col+8] = self.fwc_em # isolated pixel
         self.frame.frame_bias0 = frame_bias0
 
         # image area
@@ -337,8 +352,11 @@ class TestRemoveCosmics(unittest.TestCase):
         image_mask = np.zeros_like(image_bias0, dtype=int)
 
         # cosm_filter=2,cosm_tail=10, and mask starts at 2
-        frame_mask[1:3, 2:2+2+10+1] = 1
-        frame_mask[8, 8] = 1  # Isolated pixels remove only those pixels
+        frame_mask[self.im_st_row+1:self.im_st_row+3, 
+                   self.im_st_col+2:self.im_st_col+2+2+10+1] = 1
+        #Isolated pixels remove only those pixels
+        frame_mask[self.im_st_row+8, 
+                   self.im_st_col+8] = 1
         image_mask[1:3, 2:2+2+10+1] = 1
         image_mask[8, 8] = 1  # Isolated pixels remove only those pixels
 
@@ -404,10 +422,15 @@ class TestRemoveCosmics(unittest.TestCase):
 
         # full frame
         frame_bias0 = np.zeros((meta.frame_rows, meta.frame_cols))
-        frame_bias0[1:3, 2:4] = self.fwc_em  # Fake hit
-        frame_bias0[1:3, 4] = self.fwc_em/2  # Trigger end cosmic thresh
-        frame_bias0[1:3, 5:] = 1.  # Fake tail
-        frame_bias0[8, 8] = self.fwc_pp*self.em_gain # isolated pixel
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+2:self.im_st_col+4] = self.fwc_em  #Fake hit
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+4] = self.fwc_em/2#Trigger end cosmic thresh
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+5:] = 1.  # Fake tail
+        #isolated pixel
+        frame_bias0[self.im_st_row+8, 
+                    self.im_st_col+8] = self.fwc_pp*self.em_gain
         self.frame.frame_bias0 = frame_bias0
 
         # image area
@@ -421,8 +444,10 @@ class TestRemoveCosmics(unittest.TestCase):
 
         # cosm_filter=2,cosm_tail=10, and mask starts at 2
         frame_mask = np.zeros_like(frame_bias0, dtype=int)
-        frame_mask[1:3, 2:2+2+10+1] = 1
-        frame_mask[8, 8] = 1  # Isolated pixels remove only those pixels
+        frame_mask[self.im_st_row+1:self.im_st_row+3, 
+                   self.im_st_col+2:self.im_st_col+2+2+10+1] = 1
+        # Isolated pixels remove only those pixels
+        frame_mask[self.im_st_row+8, self.im_st_col+8] = 1 
         # cosm_filter=2,cosm_tail=10, and mask starts at 2
         image_mask = np.zeros_like(image_bias0, dtype=int)
         image_mask[1:3, 2:2+2+10+1] = 1

--- a/proc_cgi_frame_NTR/proc_cgi_frame/gsw_emccd_frame.py
+++ b/proc_cgi_frame_NTR/proc_cgi_frame/gsw_emccd_frame.py
@@ -151,7 +151,8 @@ class EMCCDFrame:
                             plat_thresh=plat_thresh,
                             cosm_filter=cosm_filter,
                             cosm_box=cosm_box,
-                            cosm_tail=cosm_tail
+                            cosm_tail=cosm_tail,
+                            meta=self.meta
                             )
         # same thing, but now making masks for full frame (for calibrate_darks)
 
@@ -167,6 +168,7 @@ class EMCCDFrame:
                             cosm_filter=cosm_filter,
                             cosm_box=cosm_box,
                             cosm_tail=cosm_tail,
+                            meta=self.meta,
                             mode='full'
                             )
 

--- a/proc_cgi_frame_NTR/proc_cgi_frame/gsw_remove_cosmics.py
+++ b/proc_cgi_frame_NTR/proc_cgi_frame/gsw_remove_cosmics.py
@@ -3,9 +3,10 @@
 
 import numpy as np
 from scipy.ndimage import median_filter
+from .read_metadata import Metadata
 
 def remove_cosmics(image, fwc, sat_thresh, plat_thresh, cosm_filter, cosm_box,
-                   cosm_tail, mode='image'):
+                   cosm_tail, meta=None, mode='image'):
     """Identify and remove saturated cosmic ray hits and tails.
 
     Use sat_thresh (interval 0 to 1) to set the threshold above which cosmics
@@ -44,6 +45,12 @@ def remove_cosmics(image, fwc, sat_thresh, plat_thresh, cosm_filter, cosm_box,
         to mask.  If cosm_tail is greater than the number of
         columns left to the end of the row from the cosmic
         plateau, the cosmic masking ends at the end of the row. Defaults to 10.
+    meta : Metadata class instance
+        Metadata class instance, which is used to determine whether the
+        beginning of a plateau is not in the image area, in which case no 
+        cosmic ray masking should occur.  Only relevant when mode is 'full'.
+        Defaults to None, in which case masking is allowed anywhere on the 
+        input frame.
     mode : string
         If 'image', an image-area input is assumed, and if the input
         tail length is longer than the length to the end of the image-area row,
@@ -70,9 +77,25 @@ def remove_cosmics(image, fwc, sat_thresh, plat_thresh, cosm_filter, cosm_box,
      ......|<-plateau->|<------------------tail---------->|.........
 
     B Nemati and S Miller - UAH - 02-Oct-2018
+    Kevin Ludwick - UAH - 2024
 
     """
     mask = np.zeros(image.shape, dtype=int)
+    if meta is not None:
+        if not isinstance(meta, Metadata):
+            raise Exception('meta must be an instance of the Metadata class.')
+    if meta is not None and mode=='full':
+        im_num_rows = meta.geom['image']['rows']
+        im_num_cols = meta.geom['image']['cols']
+        im_starting_row = meta.geom['image']['r0c0'][0]
+        im_ending_row = im_starting_row + im_num_rows
+        im_starting_col = meta.geom['image']['r0c0'][1]
+        im_ending_col = im_starting_col + im_num_cols
+    else:
+        im_starting_row = 0
+        im_ending_row = mask.shape[0] - 1 # - 1 to get the index, not size
+        im_starting_col = 0
+        im_ending_col = mask.shape[1] - 1 # - 1 to get the index, not size
 
     # Do a cheap prefilter for rows that don't have anything bright
     max_rows = np.max(image, axis=1)
@@ -80,7 +103,8 @@ def remove_cosmics(image, fwc, sat_thresh, plat_thresh, cosm_filter, cosm_box,
 
     for i in i_streak_rows:
         row = image[i]
-
+        if i < im_starting_row or i > im_ending_row:
+            continue
         # Find if and where saturated plateaus start in streak row
         i_begs = find_plateaus(row, fwc, sat_thresh, plat_thresh, cosm_filter)
 
@@ -89,6 +113,8 @@ def remove_cosmics(image, fwc, sat_thresh, plat_thresh, cosm_filter, cosm_box,
         ex_l = np.array([])
         if i_begs is not None:
             for i_beg in i_begs:
+                if i_beg < im_starting_col or i_beg > im_ending_col:
+                    continue
                 # implement cosm_tail
                 if i_beg+cosm_filter+cosm_tail+1 > mask.shape[1]:
                     ex_l = np.append(ex_l,
@@ -98,10 +124,11 @@ def remove_cosmics(image, fwc, sat_thresh, plat_thresh, cosm_filter, cosm_box,
                                 mask.shape[1]))
                 mask[i, i_beg:streak_end] = 1
                 # implement cosm_box
-                st_row = max(i-cosm_box, 0)
-                end_row = min(i+cosm_box+1, mask.shape[0])
-                st_col = max(i_beg-cosm_box, 0)
-                end_col = min(i_beg+cosm_box+1, mask.shape[1])
+                # can't have cosm_box appear in non-image pixels
+                st_row = max(i-cosm_box, im_starting_row)
+                end_row = min(i+cosm_box+1, im_ending_row+1)
+                st_col = max(i_beg-cosm_box, im_starting_col)
+                end_col = min(i_beg+cosm_box+1, im_ending_col+1)
                 mask[st_row:end_row, st_col:end_col] = 1
                 pass
 

--- a/proc_cgi_frame_NTR/proc_cgi_frame/ut_gsw_emccd_frame.py
+++ b/proc_cgi_frame_NTR/proc_cgi_frame/ut_gsw_emccd_frame.py
@@ -231,6 +231,9 @@ class TestRemoveCosmics(unittest.TestCase):
         self.cosm_filter = 2
         self.cosm_box = 0
         self.cosm_tail = 2200
+        self.meta = Metadata() # using metadata.yaml
+        self.im_st_row = self.meta.geom['image']['r0c0'][0]
+        self.im_st_col = self.meta.geom['image']['r0c0'][1]
         pass
 
     def test_cosm_box_works(self):
@@ -243,13 +246,17 @@ class TestRemoveCosmics(unittest.TestCase):
         """Verify method returns correct mask with a CR."""
         # full frame
         frame_bias0 = np.zeros((meta.frame_rows, meta.frame_cols))
-        frame_bias0[1:3, 2:4] = self.fwc_em  # Fake hit
-        frame_bias0[1:3, 4] = self.fwc_em/2  # Trigger end cosmic thresh
-        frame_bias0[1:3, 5:] = 1.  # Fake tail
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+2:self.im_st_col+4] = self.fwc_em  #Fake hit
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+4] = self.fwc_em/2#Trigger end cosmic thresh
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+5:] = 1.  # Fake tail
         self.frame.frame_bias0 = frame_bias0
         frame_mask = np.zeros_like(frame_bias0, dtype=int)
         # cosm_filter=2,cosm_tail=10, and mask starts at 2
-        frame_mask[1:3, 2:2+2+10+1] = 1
+        frame_mask[self.im_st_row+1:self.im_st_row+3, 
+                   self.im_st_col+2:self.im_st_col+2+2+10+1] = 1
 
         # image area
         image_bias0 = np.zeros((meta.geom['image']['rows'],
@@ -281,9 +288,13 @@ class TestRemoveCosmics(unittest.TestCase):
 
         # full frame
         frame_bias0 = np.zeros((meta.frame_rows, meta.frame_cols))
-        frame_bias0[1:3, 2:4] = self.fwc_pp - 1  # Fake hit *below threshold*
-        frame_bias0[1:3, 4] = self.fwc_pp/2  # Trigger end cosmic thresh
-        frame_bias0[1:3, 5:] = 1.  # Fake tail
+        # Fake hit *below threshold*
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+2:self.im_st_col+4] = self.fwc_pp - 1  
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+4] = self.fwc_pp/2#Trigger end cosmic thresh
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+5:] = 1.  # Fake tail
         self.frame.frame_bias0 = frame_bias0
 
         # image area
@@ -318,10 +329,14 @@ class TestRemoveCosmics(unittest.TestCase):
 
         # full frame
         frame_bias0 = np.zeros((meta.frame_rows, meta.frame_cols))
-        frame_bias0[1:3, 2:4] = self.fwc_em  # Fake hit
-        frame_bias0[1:3, 4] = self.fwc_em/2  # Trigger end cosmic thresh
-        frame_bias0[1:3, 5:] = 1.  # Fake tail
-        frame_bias0[8, 8] = self.fwc_em # isolated pixel
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+2:self.im_st_col+4] = self.fwc_em  #Fake hit
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+4] = self.fwc_em/2#Trigger end cosmic thresh
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+5:] = 1.  # Fake tail
+        frame_bias0[self.im_st_row+8, 
+                    self.im_st_col+8] = self.fwc_em # isolated pixel
         self.frame.frame_bias0 = frame_bias0
 
         # image area
@@ -337,8 +352,11 @@ class TestRemoveCosmics(unittest.TestCase):
         image_mask = np.zeros_like(image_bias0, dtype=int)
 
         # cosm_filter=2,cosm_tail=10, and mask starts at 2
-        frame_mask[1:3, 2:2+2+10+1] = 1
-        frame_mask[8, 8] = 1  # Isolated pixels remove only those pixels
+        frame_mask[self.im_st_row+1:self.im_st_row+3, 
+                   self.im_st_col+2:self.im_st_col+2+2+10+1] = 1
+        #Isolated pixels remove only those pixels
+        frame_mask[self.im_st_row+8, 
+                   self.im_st_col+8] = 1
         image_mask[1:3, 2:2+2+10+1] = 1
         image_mask[8, 8] = 1  # Isolated pixels remove only those pixels
 
@@ -404,10 +422,15 @@ class TestRemoveCosmics(unittest.TestCase):
 
         # full frame
         frame_bias0 = np.zeros((meta.frame_rows, meta.frame_cols))
-        frame_bias0[1:3, 2:4] = self.fwc_em  # Fake hit
-        frame_bias0[1:3, 4] = self.fwc_em/2  # Trigger end cosmic thresh
-        frame_bias0[1:3, 5:] = 1.  # Fake tail
-        frame_bias0[8, 8] = self.fwc_pp*self.em_gain # isolated pixel
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+2:self.im_st_col+4] = self.fwc_em  #Fake hit
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+4] = self.fwc_em/2#Trigger end cosmic thresh
+        frame_bias0[self.im_st_row+1:self.im_st_row+3, 
+                    self.im_st_col+5:] = 1.  # Fake tail
+        #isolated pixel
+        frame_bias0[self.im_st_row+8, 
+                    self.im_st_col+8] = self.fwc_pp*self.em_gain
         self.frame.frame_bias0 = frame_bias0
 
         # image area
@@ -421,8 +444,10 @@ class TestRemoveCosmics(unittest.TestCase):
 
         # cosm_filter=2,cosm_tail=10, and mask starts at 2
         frame_mask = np.zeros_like(frame_bias0, dtype=int)
-        frame_mask[1:3, 2:2+2+10+1] = 1
-        frame_mask[8, 8] = 1  # Isolated pixels remove only those pixels
+        frame_mask[self.im_st_row+1:self.im_st_row+3, 
+                   self.im_st_col+2:self.im_st_col+2+2+10+1] = 1
+        # Isolated pixels remove only those pixels
+        frame_mask[self.im_st_row+8, self.im_st_col+8] = 1 
         # cosm_filter=2,cosm_tail=10, and mask starts at 2
         image_mask = np.zeros_like(image_bias0, dtype=int)
         image_mask[1:3, 2:2+2+10+1] = 1


### PR DESCRIPTION
There was a update to proc_cgi_frame and cal repos as of today (10/1/24).  The update fixes the cosmic ray flagging in the case of full-frame outputs to only occur for the image area.  

I am also working on an update to the end-to-end tests for the DRP which involve running the data through the II&T code and the DRP within the same script, so I would like to update this repo accordingly with the updated II&T code.