### PR TITLE
to be correct for latest numpy version and backward-compatible

### DIFF
--- a/Calibration_NTR/cal/kgain/calibrate_kgain.py
+++ b/Calibration_NTR/cal/kgain/calibrate_kgain.py
@@ -508,7 +508,7 @@ def calibrate_kgain(stack_arr, stack_arr2, emgain, min_val, max_val,
         
         added_deviations_shot_arr = [
                 np.sqrt(np.square(np.reshape(std_diffs[x], 
-                newshape=(-1, 1))) - complex(rn_std[x])**2)
+                (-1, 1))) - complex(rn_std[x])**2)
                 for x in range(len(rn_std))
                 ]
         


### PR DESCRIPTION
Very simple fix to accommodate latest numpy version, which eliminated "newshape" argument with "shape".  The solution is to leave out the argument name, and the second argument in the function is what is needed to be specified in whichever numpy version used.